### PR TITLE
V189 improvements

### DIFF
--- a/bin/alloccli/alloc.py
+++ b/bin/alloccli/alloc.py
@@ -664,8 +664,7 @@ class alloc(object):
   def dbg(self, s):
     """Print a message to the screen (stdout) for debugging only."""
     if self.debug:
-      print "DBG " + str(s)
-      sys.stdout.flush()
+      sys.stderr.write("DBG " + str(s) + '\n')
 
   def parse_email(self, email):
     """Parse an email address from this: Jon Smit <js@example.com> into: addr, name."""

--- a/bin/alloccli/alloc.py
+++ b/bin/alloccli/alloc.py
@@ -385,7 +385,7 @@ class alloc(object):
     """Coerce a dict with perhaps missing keys or a value of None to an empty string."""
     r = defaultdict(str)
     for a, b in row.items():
-      r[a] = str(b or '')
+      r[a] = b or ''
     return r
 
   def print_task(self, taskID, prependEmailHeader=False, children=False):

--- a/bin/alloccli/alloc.py
+++ b/bin/alloccli/alloc.py
@@ -421,6 +421,7 @@ class alloc(object):
       if r['projectName']:  s += '\nProject: '+r['projectName']
       if 'projectPriorityLabel' in r and r['projectPriorityLabel']: s += ' ['+r['projectPriorityLabel']+']'
       if r['parentTaskID']: s += '\nParent Task: '+r['parentTaskID']
+      if r['tags']: s += '\nTags: '+r['tags']
       if r['projectName'] or r['parentTaskID']: s += '\n'
       if r['creator_name']:  s += '\nCreator:  '+r['creator_name'].ljust(25)+' '+r['dateCreated']
       if r['assignee_name']: s += '\nAssigned: '+r['assignee_name'].ljust(25)+' '+r['dateAssigned']

--- a/bin/alloccli/alloc_output_handler.py
+++ b/bin/alloccli/alloc_output_handler.py
@@ -188,6 +188,10 @@ class alloc_output_handler:
  
     if alloc.csv:
       csv_table = csv.writer(sys.stdout, lineterminator="\n")
+      # FIXME: This shows the header for the CSV. It should have a CLI
+      # option to turn it on, but for now, just print it always and let
+      # the user filter it out if necessary.
+      csv_table.writerow([unicode(s).encode('utf-8') for s in field_names])
       for row in rows:
         csv_table.writerow([unicode(s).encode('utf-8') for s in row])
 


### PR DESCRIPTION
A handful of small but significant improvements:

* Don't cast to string because this breaks unicode
* alloc view should print tags
* debug output should go to stderr
* always print header row for CSV output

Not sure if you want these done on 'master', but doing so will require some fancy cherry-picking, I think, because of apparent code refactoring.